### PR TITLE
Export zoneinfo from go sdk.

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -70,9 +70,7 @@ filegroup(
     ]),
 )
 
-filegroup(
-    name = "zoneinfo",
-    srcs = [
-        "lib/time/zoneinfo.zip",
-    ],
+exports_files(
+    ["lib/time/zoneinfo.zip"],
+    visibility = ["//visibility:public"],
 )

--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -69,3 +69,10 @@ filegroup(
         "pkg/**",
     ]),
 )
+
+filegroup(
+    name = "zoneinfo",
+    srcs = [
+        "lib/time/zoneinfo.zip",
+    ],
+)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

To run the CockroachDB node, you need [to provide an archive of time zones from your environment](https://www.cockroachlabs.com/docs/v20.1/known-limitations.html#location-based-time-zone-names). And if you\`re using Bazel, it would be very convenient to use `zoneinfo.zip` from the go sdk provided by the role_go.
With this export you can refer to this archive like this `"@go_sdk//:lib/time/zoneinfo.zip"`.


